### PR TITLE
Add ability to not use the cache 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,156 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+.idea/

--- a/lumaapi/__init__.py
+++ b/lumaapi/__init__.py
@@ -280,6 +280,7 @@ class LumaClient:
 
     :param api_key: API key. If None, will be requested when needed
     :param is_cli: Whether this is being used as a CLI (internal use only)
+    :param use_cache: Whether to cache the auth headers (default True)
     """
     def __init__(self,
                  api_key: Optional[str] = None,

--- a/lumaapi/__init__.py
+++ b/lumaapi/__init__.py
@@ -290,9 +290,9 @@ class LumaClient:
         """
         self.auth_header = None
         self.is_cli = is_cli
+        self.use_cache = use_cache
         if api_key is not None:
             self.auth(api_key)
-        self.use_cache = use_cache
 
 
     def credits(self) -> LumaCreditInfo:
@@ -341,11 +341,10 @@ class LumaClient:
             # Prompt user for API key
             if api_key is None:
                 api_key = input("Enter your Luma API key (get from https://captures.lumalabs.ai/dashboard): ").strip()
-
+            result = {"Authorization": 'luma-api-key=' + api_key}
             if self.use_cache:
                 os.makedirs(CACHE_DIR, exist_ok=True)
                 with open(AUTH_FILE, "w") as f:
-                    result = {"Authorization": 'luma-api-key=' + api_key}
                     json.dump(result, f)
 
             print("Verifying api-key...")

--- a/lumaapi/__init__.py
+++ b/lumaapi/__init__.py
@@ -283,7 +283,8 @@ class LumaClient:
     """
     def __init__(self,
                  api_key: Optional[str] = None,
-                 is_cli: bool = False):
+                 is_cli: bool = False,
+                 use_cache: bool = True):
         """
         Construct LumaClient
         """
@@ -291,6 +292,7 @@ class LumaClient:
         self.is_cli = is_cli
         if api_key is not None:
             self.auth(api_key)
+        self.use_cache = use_cache
 
 
     def credits(self) -> LumaCreditInfo:
@@ -329,7 +331,6 @@ class LumaClient:
 
         :return: dict, headers to use for authenticated requests (:code:`Authorization: luma-api-key=<api_key>`)
         """
-        os.makedirs(CACHE_DIR, exist_ok=True)
         if api_key is None and self.auth_header is not None:
             result = self.auth_header
         elif api_key is None and os.path.isfile(AUTH_FILE):
@@ -340,9 +341,12 @@ class LumaClient:
             # Prompt user for API key
             if api_key is None:
                 api_key = input("Enter your Luma API key (get from https://captures.lumalabs.ai/dashboard): ").strip()
-            with open(AUTH_FILE, "w") as f:
-                result = {"Authorization": 'luma-api-key=' + api_key}
-                json.dump(result, f)
+
+            if self.use_cache:
+                os.makedirs(CACHE_DIR, exist_ok=True)
+                with open(AUTH_FILE, "w") as f:
+                    result = {"Authorization": 'luma-api-key=' + api_key}
+                    json.dump(result, f)
 
             print("Verifying api-key...")
             # Check it by getting credits


### PR DESCRIPTION
Description - 

Creating temp folders for the caches doesn't work on AWS Lamdba. So I have added the ability to provide a prop to not cache the auth headers. 

Changes - 

- Add `use_cache` to LumaClient with a default to True to keep current behaviour 
- Added a `.gitignore` with the general defaults. I can revert this if you don't want one